### PR TITLE
Bump crate version and add fix for latest Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ defmt-rtt = { version = "1.1", optional = true }
 # dependencies for ESP
 esp-hal = { version = "1.0", features = ["unstable"] }
 esp-rtos = { version = "0.2", features = ["embassy", "esp-radio"] }
-esp-bootloader-esp-idf = "0.2"
+esp-bootloader-esp-idf = "0.4"
 esp-radio = { version = "0.17", features = ["wifi"] }
 esp-alloc = { version = "0.9" }
 esp-wifi-sys = { version = "0.8.1", default-features = false, optional = true }
@@ -31,7 +31,7 @@ esp-wifi-sys = { version = "0.8.1", default-features = false, optional = true }
 embassy-executor = "0.9"
 embassy-time = "0.5"
 embassy-sync = "0.7"
-embassy-net = { version = "0.6", features = [
+embassy-net = { version = "0.8", features = [
     "tcp",
     "udp",
     "dns",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(impl_trait_in_assoc_type)]
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;


### PR DESCRIPTION
Bump embassy-net to version = "0.8"
Add
#![feature(impl_trait_in_assoc_type)]

Compiles and tested on hardware.
